### PR TITLE
Improve spell-checker

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: jrNotes
 Title: Jumping Rivers: Helper Package for Notes
-Version: 0.6.9
+Version: 0.6.10
 Authors@R: 
     person(given = "Jumping",
            family = "Rivers",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# jrNotes 0.6.10 _2020-09-10_
+  * Improvement: Order output of `check_spelling()` by chapter
+  * Improvement: Improve readability of output of `check_spelling()`
+
 # jrNotes 0.6.9 _2020-09-09_
   * Feature: Add links to advert page 
 

--- a/R/check_spelling.R
+++ b/R/check_spelling.R
@@ -16,6 +16,7 @@ make_wordlist = function(spelling_results) {
 #'
 #' @description check_spelling runs a spell check on all c*.Rmd files.
 #' @importFrom spelling spell_check_files
+#' @importFrom unnest tidyr
 #' @export
 check_spelling = function() {
   fnames = list.files(pattern = "^c.*\\.Rmd$")
@@ -34,8 +35,12 @@ check_spelling = function() {
               and append to inst/WORDLIST.")
   msg_info(msg, padding = 2)
 
+  # Order spelling mistakes grouped by chapter
+  in_words = unnest(in_words, cols=c(found))
+  in_words = with(in_words, in_words[order(found, word) , ])
+
   for (i in seq_len(nrow(in_words))) {
-    msg_info(glue("{in_words[i, 1]}  {in_words[i, 2]}"), padding = 4)
+    msg_info(glue("{in_words[i, 1]}\t\t{in_words[i, 2]}"), padding = 4)
   }
   make_wordlist(in_words)
   return(invisible(in_words))


### PR DESCRIPTION
Addresses #36 


Adding the `\t` in `glue(in_words[i,1] \t in_words[i, 2]) isn't perfect, but I do find the output more readable than when the `\t` was `   `.