### PR TITLE
'fix' clone_git_repo

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: jrNotes
 Title: Jumping Rivers: Helper Package for Notes
-Version: 0.7.2
+Version: 0.7.3
 Authors@R: 
     person(given = "Jumping",
            family = "Rivers",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# jrNotes 0.7.3 _2020-09-15_
+  * Bug: repos created with `jrNotes::clone_git_repo` could not be pushed
+
 # jrNotes 0.7.2 _2020-09-10_
   * Improvement: Improve readability of output of `check_spelling()`
   * Feature: Force per course WORDLIST

--- a/R/clone_git_template.R
+++ b/R/clone_git_template.R
@@ -51,13 +51,10 @@ clone_git_template = function(name = NULL,
 
   # Ask use whether they're making a python or r course
   language_id = utils::menu(c("Python", "R"), title = "Are you creating a Python or R course?")
-  language_path = tolower(c("Python/", "R/")[language_id])
+  language_path = c("python/", "r/")[language_id]
 
   # Construct url in correct subgroup
-  git_repo = glue::glue("git@gitlab.com:jumpingrivers-notes/",
-                        language_path,
-                        name,
-                        ".git")
+  git_repo = glue::glue("git@gitlab.com:jumpingrivers-notes/{language_path}/{name}.git")
   system2("git", args = c("remote", "add", "origin", git_repo))
 
   if (push) {

--- a/R/clone_git_template.R
+++ b/R/clone_git_template.R
@@ -34,11 +34,13 @@ clone_git_template = function(name = NULL,
 
   repo_name = file.path(path, name)
   system2("git", args = c("clone",
-                          "--depth",
-                          "1",
                           "git@gitlab.com:jumpingrivers-notes/template.git", #nolint
                           repo_name))
   setwd(repo_name)
+  # Don't bring templates history
+  system2("rm", args = c("-rf", ".git"))
+  system2("git", args = c("init"))
+
 
   ### remove current README and add general notes one
   file.remove("README.md")
@@ -48,7 +50,7 @@ clone_git_template = function(name = NULL,
 
   git_repo = paste0("git@gitlab.com:jumpingrivers-notes/course_notes/",
                     name, ".git")
-  system2("git", args = c("remote", "set-url", "origin", git_repo))
+  system2("git", args = c("remote", "add", "origin", git_repo))
 
   if (push) {
     system2("git", args = c("push", "-u", "origin", "master"))

--- a/R/clone_git_template.R
+++ b/R/clone_git_template.R
@@ -48,8 +48,16 @@ clone_git_template = function(name = NULL,
   build_status = "Package build status: [![Build Status](https://api.travis-ci.org/jr-packages/jrXxxx.png?branch=master)](https://travis-ci.org/jr-packages/)" #nolint
   writeLines(c(title, build_status), "README.md")
 
-  git_repo = paste0("git@gitlab.com:jumpingrivers-notes/course_notes/",
-                    name, ".git")
+
+  # Ask use whether they're making a python or r course
+  language_id = utils::menu(c("Python", "R"), title="Are you creating a Python or R course?")
+  language_path = tolower(c("Python/", "R/")[language_id])
+
+  # Construct url in correct subgroup
+  git_repo = glue::glue("git@gitlab.com:jumpingrivers-notes/",
+                        language_path,
+                        name,
+                        ".git")
   system2("git", args = c("remote", "add", "origin", git_repo))
 
   if (push) {

--- a/R/clone_git_template.R
+++ b/R/clone_git_template.R
@@ -50,7 +50,7 @@ clone_git_template = function(name = NULL,
 
 
   # Ask use whether they're making a python or r course
-  language_id = utils::menu(c("Python", "R"), title="Are you creating a Python or R course?")
+  language_id = utils::menu(c("Python", "R"), title = "Are you creating a Python or R course?")
   language_path = tolower(c("Python/", "R/")[language_id])
 
   # Construct url in correct subgroup


### PR DESCRIPTION
This is a work in progress and addresses #42 

`jrNotes::clone_git_repo()` has two issues to address:

- [x] Clones cannot be pushed because they are shallow clones (created with the `--depth` argument)
- [x] We no longer have `jumpingrivers-notes/course_notes`, which `clone_git_repo` uses to construct the remote url. 
