### PR TITLE
Move float package from notes template to jrStyle

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: jrNotes
 Title: Jumping Rivers: Helper Package for Notes
-Version: 0.7.5
+Version: 0.7.6
 Authors@R: 
     person(given = "Jumping",
            family = "Rivers",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# jrNotes 0.7.6 _2020-09-22_
+  * Improvement: Add `\usepackage{float}` to `jrStyle.sty` (previously
+    specified in `header-includes` of `main.Rmd` in notes template)
+
 # jrNotes 0.7.5 _2020-09-21_
   * Feature: Include line number indicator in `check_section_headers()` error message
   * Feature: Add first test to `{jrNotes}` (`check_section_headers()`)

--- a/inst/extdata/jrStyle.sty
+++ b/inst/extdata/jrStyle.sty
@@ -159,3 +159,5 @@
     }%
   }%
 \fi
+
+\usepackage{float}


### PR DESCRIPTION
`\usepackage{float}` was included in `main.Rmd` in the notes template, but should likely be in `jrStyle.sty` instead.

See https://gitlab.com/jumpingrivers-notes/template/-/commit/35139ecfba8bbe9869bbdcb55547dfe8f4e9a6ef for corresponding alterations to the notes template.