### PR TITLE
47 notes content should start on page 1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: jrNotes
 Title: Jumping Rivers: Helper Package for Notes
-Version: 0.7.6
+Version: 0.7.7
 Authors@R: 
     person(given = "Jumping",
            family = "Rivers",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# jrNotes 0.7.7 _2020-09-22_
+  * Improvement: Don't add page numbers to advert and course-dependencies
+  * Improvement: Number course contents from page 1
+
 # jrNotes 0.7.6 _2020-09-22_
   * Improvement: Add `\usepackage{float}` to `jrStyle.sty` (previously
     specified in `header-includes` of `main.Rmd` in notes template)

--- a/inst/extdata/advert.tex
+++ b/inst/extdata/advert.tex
@@ -1,3 +1,5 @@
+\thispagestyle{empty}
+
 {\huge CREATING CLARITY \\ \\ WITH YOUR DATA.}
 \\
 
@@ -48,3 +50,6 @@ Jumping Rivers is an analytics company whose passion is data and machine learnin
   \item Statistical Modelling
   \item And many more!
 \end{itemize}
+
+\clearpage
+\pagenumbering{arabic}

--- a/inst/extdata/course-dependencies.tex
+++ b/inst/extdata/course-dependencies.tex
@@ -1,3 +1,4 @@
+\thispagestyle{empty}
 \newpage
 \begin{figure*}[h]
 \includegraphics[angle=90,width=0.8\textwidth]{dependencies.png}


### PR DESCRIPTION
Addresses and closes #47 

These changes:
  * Start counting the **course content** from page 1.
  * Remove the page number from the advert (i don't think the advert should have a page number)
  * Remove the page number from the course dependencies page (also don't think the ad should be numbered)