### PR TITLE
Fix get_logo_path.R broken by config.yml changes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: jrNotes
 Title: Jumping Rivers: Helper Package for Notes
-Version: 0.7.8
+Version: 0.7.9
 Authors@R: 
     person(given = "Jumping",
            family = "Rivers",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# jrNotes 0.7.9 _2020-09-24_
+  * Bug: Fix bug introduced in `get_logo_path.R` by changes to `config.yml`
+
 # jrNotes 0.7.8 _2020-09-23_
   * Improvement: Stop using generic `packages` in config.yml
 

--- a/R/get_logo_path.R
+++ b/R/get_logo_path.R
@@ -89,8 +89,9 @@ create_version = function() {
   con = config::get()
   version = con$version
 
-  pkg_name = con$packages[[1]]
+  version = con$version
   if (get_repo_language() == "r") {
+    pkg_name = get_r_pkg_name()
     pkg_ver = packageVersion(pkg_name)
   } else {
     pkg_ver = ""


### PR DESCRIPTION
The latest changes to the `config.yml` layout broke `create_version()` of `get_logo_path.R`.

Apply Colin's fix from Slack