### PR TITLE
Pkgs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: jrNotes
 Title: Jumping Rivers: Helper Package for Notes
-Version: 0.8.9
+Version: 0.9.0
 Authors@R:
     person(given = "Jumping",
            family = "Rivers",
@@ -20,6 +20,7 @@ Imports:
     crayon,
     digest,
     dplyr,
+    formatR,
     fs,
     gert,
     glue,
@@ -33,6 +34,7 @@ Imports:
     qpdf,
     reticulate (>= 1.11.1),
     rlang,
+    rmarkdown (>= 2.3),
     rstudioapi,
     spelling,
     stringr,
@@ -43,9 +45,6 @@ Imports:
 Suggests:
     covr,
     drat,
-    formatR,
-    ggplot2,
-    rmarkdown (>= 2.3),
     testthat
 VignetteBuilder: 
     knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,36 +1,23 @@
-# jrNotes 0.8.9 _2020-10-05_
-  * Bug: check_pkgs shouldn't raise an error on CI
+# jrNotes 0.9.0 _2020-10-06_
+  * Bug: check title length incorrectly detected wrong line breaks
+  * Internal: Remove {ggplot2} from Suggests
+  * Internal: Move {rmarkdown} and {formatR} to Imports
 
-# jrNotes 0.8.8 _2020-10-05_
-  * Improvement: Add the imports from the r_pkg to WORDLIST
-  * Improvement: Output unstaged files
-  * Improvement: Record the error origin
-  
-# jrNotes 0.8.7 _2020-10-01_
+# jrNotes 0.8.* _2020-10-05_
   * Feature: Add addin to collapse minor NEWS versions
-
-# jrNotes 0.8.6 _2020-09-30_
+  * Feature: Point version number shouldn't go past 9
+  * Feature: Check title length
+  * Improvement: Add the imports from the r_pkg to WORDLIST
+  * Improvement: Output unstaged file names
+  * Improvement: Record the error origin
+  * Improvement: specify config_issue = TRUE in check_config.R
   * Improvement: `check_url()` prints problem URLs along with their status
-
-# jrNotes 0.8.5 _2020-09-28_
-  * Feature: Add R, Python & deb_packages to spelling exceptions
-
-# jrNotes 0.8.4 _2020-09-28_
-  * Bug: Fix `get_logo_path()` for python notes
-
-# jrNotes 0.8.3 _2020-09-28_
+  * Improvement: Add R, Python & deb_packages to spelling exceptions
   * Internal: Use `{cli}` instead of our own system
   * Internal: Set `depth` equal to 1 when cloning template
-
-# jrNotes 0.8.2 _2020-09-25_
-  * Feature: Point version number shouldn't go past 9
-
-# jrNotes 0.8.1 _2020-09-24_
-  * Feature: Check title length
-
-# jrNotes 0.8.0 _2020-09-24_
   * Bug: Don't lookup package version twice in get_logo_path()
-  * Improvement: specify config_issue = TRUE in check_config.R
+  * Bug: check_pkgs shouldn't raise an error on CI
+  * Bug: Fix `get_logo_path()` for python notes
 
 # jrNotes 0.7.* _2020-09-24_
   * Improvement: Stop using generic `packages` in config.yml

--- a/R/check_config.R
+++ b/R/check_config.R
@@ -13,7 +13,7 @@ check_config = function() {
   ## Check length of title on front page
   front = config::get("front")
   ## Remove line breaks & right hand whitespace
-  front = stringr::str_split(front, "\\\\")[[1]][1]
+  front = stringr::str_split(front, "\\\\\\\\")[[1]][1]
   front = stringr::str_trim(front, side = "right")
   if (stringr::str_length(front) > 25L) {
     msg_error("Title is too long. Add a line break?", padding = TRUE)


### PR DESCRIPTION
 * Bug fix in check title length. To add line breaks in title you need to escape, e.g. `\\\\`. So to detect you need twice as many `\`.
    - I noticed this on the tidyverse course. We had only two `\\` in the title, which didn't cause a line break, but the check said it was fine.
 * Suggests: ggplot2 isn't used by this package. So this would allow errors to creep in with notes
   - This may break some notes, if we had forgotten to add it as a dependency for jrPkg. But then that's what it's trying to catch.
 * rmarkdown and formatR are required to build our notes. So should be in imports
   - Currently messing about with Docker. In theory, we should just install jrNotes and jrPkg to build our notes. The above was missing