### PR TITLE
Improve styling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: jrNotes
 Title: Jumping Rivers: Helper Package for Notes
-Version: 0.9.2
+Version: 0.9.3
 Authors@R:
     person(given = "Jumping",
            family = "Rivers",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# jrNotes 0.9.3 _2020-10-12_
+  * Improvement: Improved styling of chapter section and subsections
+
 # jrNotes 0.9.2 _2020-10-12_
   * Internal: Add extra LaTeX packages to `jrStyle` to support RStan course
 

--- a/inst/extdata/jrStyle.sty
+++ b/inst/extdata/jrStyle.sty
@@ -104,6 +104,8 @@
 \definecolor{messagecolor}{rgb}{0, 0, 0}
 \definecolor{warningcolor}{rgb}{1, 0, 1}
 \definecolor{errorcolor}{rgb}{1, 0, 0}
+
+\definecolor{CTsemi}{gray}{0.55}
 %------------------------------------------------------------------------------
 
 %------------------------------------------------------------------------------
@@ -203,4 +205,50 @@
   \thispagestyle{empty}%
   \clearpage%
 }
+%------------------------------------------------------------------------------
+
+%------------------------------------------------------------------------------
+% Formatting of chapters, sections, subsections etc.
+
+\newlength\TitleOverhang
+\setlength\TitleOverhang{2.5mm}
+
+% Define titlehang to let sections etc protrude margin
+\newcommand\titlehang[1]{%
+  \llap{%
+    #1\hspace{\TitleOverhang}
+  }%
+}
+
+% Big 'ol chapter number
+\newfontfamily\chapterNumber[Scale=6]{Linux Libertine O}
+
+
+% Format chapter
+\titleformat{\chapter}%
+[display]% shape
+{\relax}% format applied to label+text
+{\mbox{}\marginpar{\vspace*{-3\baselineskip}%
+  \color{CTsemi}\chapterNumber\thechapter}}% label
+{0em}% horizontal separation between label and title body
+{\raggedright\slshape\huge}% before the title body
+[\normalsize\vspace*{.8\baselineskip}\titlerule]% after the title body
+
+% Format section
+\titleformat{\section}%
+[block]% shape
+{\Large}% format applied to label+text
+{\titlehang\thesection}% label with titlehang
+{0em}% horizontal separation between label and title body
+{\slshape}% code before the title body
+[]% after the title body
+
+% Format subsection
+\titleformat{\subsection}%
+[block]% shape
+{\large}% format applied to label+text
+{\titlehang\thesubsection}% label with titlehang
+{0em}% horizontal separation between label and title body
+{\slshape}% before the title body
+[]% after the title body
 %------------------------------------------------------------------------------


### PR DESCRIPTION
**Low priority**

I had these changes from elsewhere so figured I might as well integrate them if we like them.

The changes affect the styling of chapters, sections and subsections. (see imgs below)

* Chapters: Now have a hrule underneath, and the chapter number is big and moved to the right margin.
* Sections & subsections: They're section numbers hang outside the margin (I think for better readability)

![compare](https://user-images.githubusercontent.com/32269169/95739544-e9a33080-0c82-11eb-86ba-46a97a13b399.png)

** Potential disagreements **
For the hrule under chapters to make sense being the \textwdith the chapter title is wrapped
![image](https://user-images.githubusercontent.com/32269169/95739656-122b2a80-0c83-11eb-8195-c88905a483b1.png)
