### PR TITLE
Allow labelling and cross-referencing of code chunks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: jrNotes
 Title: Jumping Rivers: Helper Package for Notes
-Version: 0.9.3
+Version: 0.9.4
 Authors@R:
     person(given = "Jumping",
            family = "Rivers",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# jrNotes 0.9.4 _2020-10-13_
+  * Improvement: Allow captioning and cross-referencing of code chunks
+
 # jrNotes 0.9.3 _2020-10-12_
   * Improvement: Improved styling of chapter section and subsections
 

--- a/R/set_knitr_options.R
+++ b/R/set_knitr_options.R
@@ -97,10 +97,14 @@ set_knitr_options = function(tidy = FALSE,
   # https://stackoverflow.com/a/50717459/11021886
   hook_old = knit_hooks$get("chunk")
   knit_hooks$set(chunk = function(x, options) {
-    x = ifelse(!is.null(options$code.cap),
-               paste0(x, "\\captionof{chunk}{", options$code.cap, "}"), x)
-    x = ifelse(!is.null(options$label) & !is.null(options$code.cap),
-               paste0(x, "\\label{chk:", options$label, "}"), x)
+    # Label and caption
+    if (!is.null(options$label) & !is.null(options$code.cap)) {
+      x = paste0("\\marginpar{\\captionof{chunk}{", options$code.cap, "}",
+                 "\\label{chk:", options$label, "}}", x)
+    # Caption, no label
+    } else if (!is.null(options$code.cap)) {
+      x = paste0("\\marginpar{\\captionof{chunk}{", options$code.cap, "}}", x)
+    }
     hook_old(x, options)
   })
 

--- a/R/set_knitr_options.R
+++ b/R/set_knitr_options.R
@@ -99,7 +99,7 @@ set_knitr_options = function(tidy = FALSE,
   knit_hooks$set(chunk = function(x, options) {
     x = ifelse(!is.null(options$code.cap),
                paste0(x, "\\captionof{chunk}{", options$code.cap, "}"), x)
-    x = ifelse(!is.null(options$label),
+    x = ifelse(!is.null(options$label) & !is.null(options$code.cap),
                paste0(x, "\\label{chk:", options$label, "}"), x)
     hook_old(x, options)
   })

--- a/R/set_knitr_options.R
+++ b/R/set_knitr_options.R
@@ -94,16 +94,17 @@ set_knitr_options = function(tidy = FALSE,
     hook_output(x, options)
   })
 
-  # https://stackoverflow.com/a/50717459/11021886
   hook_old = knit_hooks$get("chunk")
   knit_hooks$set(chunk = function(x, options) {
-    # Label and caption
-    if (!is.null(options$label) & !is.null(options$code.cap)) {
-      x = paste0("\\marginpar{\\captionof{chunk}{", options$code.cap, "}",
-                 "\\label{chk:", options$label, "}}", x)
-    # Caption, no label
-    } else if (!is.null(options$code.cap)) {
-      x = paste0("\\marginpar{\\captionof{chunk}{", options$code.cap, "}}", x)
+    if (!is.null(options$code.cap)) {
+      # Open marginpar and add caption
+      tex = paste0("\\marginpar{\\captionof{chunk}{", options$code.cap, "}")
+      if (!is.null(options$label)) {
+        # Add label inside marginpar
+        tex = paste0(tex, "\\label{chk:", options$label, "}")
+      }
+      # Prepend tex and close marginpar
+      x = paste0(tex, "}", x)
     }
     hook_old(x, options)
   })

--- a/R/set_knitr_options.R
+++ b/R/set_knitr_options.R
@@ -93,6 +93,15 @@ set_knitr_options = function(tidy = FALSE,
     }
     hook_output(x, options)
   })
+
+  # https://stackoverflow.com/a/50717459/11021886
+  hook_old = knit_hooks$get("chunk")
+  knit_hooks$set(chunk = function(x, options) {
+    x = ifelse(!is.null(options$codecap), paste0(x, "\\captionof{chunk}{", options$codecap, "}"), x)
+    x = ifelse(!is.null(options$ref), paste0(x, "\\label{", options$ref, "}"), x)
+    hook_old(x, options)
+  })
+
   con = config::get()
   if (!is.null(con$knitr)) {
     do.call(knitr::opts_chunk$set, con$knitr)

--- a/R/set_knitr_options.R
+++ b/R/set_knitr_options.R
@@ -97,8 +97,8 @@ set_knitr_options = function(tidy = FALSE,
   # https://stackoverflow.com/a/50717459/11021886
   hook_old = knit_hooks$get("chunk")
   knit_hooks$set(chunk = function(x, options) {
-    x = ifelse(!is.null(options$codecap), paste0(x, "\\captionof{chunk}{", options$codecap, "}"), x)
-    x = ifelse(!is.null(options$ref), paste0(x, "\\label{", options$ref, "}"), x)
+    x = ifelse(!is.null(options$code.cap), paste0(x, "\\captionof{chunk}{", options$code.cap, "}"), x)
+    x = ifelse(!is.null(options$label), paste0(x, "\\label{chk:", options$label, "}"), x)
     hook_old(x, options)
   })
 

--- a/R/set_knitr_options.R
+++ b/R/set_knitr_options.R
@@ -97,8 +97,10 @@ set_knitr_options = function(tidy = FALSE,
   # https://stackoverflow.com/a/50717459/11021886
   hook_old = knit_hooks$get("chunk")
   knit_hooks$set(chunk = function(x, options) {
-    x = ifelse(!is.null(options$code.cap), paste0(x, "\\captionof{chunk}{", options$code.cap, "}"), x)
-    x = ifelse(!is.null(options$label), paste0(x, "\\label{chk:", options$label, "}"), x)
+    x = ifelse(!is.null(options$code.cap),
+               paste0(x, "\\captionof{chunk}{", options$code.cap, "}"), x)
+    x = ifelse(!is.null(options$label),
+               paste0(x, "\\label{chk:", options$label, "}"), x)
     hook_old(x, options)
   })
 

--- a/inst/extdata/jrStyle.sty
+++ b/inst/extdata/jrStyle.sty
@@ -257,4 +257,5 @@
 \DeclareNewFloatType{chunk}{placement=H, fileext=chk, within=chapter, name=Chunk}
 \crefname{chunk}{Chunk}{chunks}
 \Crefname{chunk}{Chunk}{Chunks}
+\captionsetup[chunk]{font=small}
 %------------------------------------------------------------------------------

--- a/inst/extdata/jrStyle.sty
+++ b/inst/extdata/jrStyle.sty
@@ -223,7 +223,6 @@
 % Big 'ol chapter number
 \newfontfamily\chapterNumber[Scale=6]{Linux Libertine O}
 
-
 % Format chapter
 \titleformat{\chapter}%
 [display]% shape
@@ -251,4 +250,11 @@
 {0em}% horizontal separation between label and title body
 {\slshape}% before the title body
 []% after the title body
+%------------------------------------------------------------------------------
+
+%------------------------------------------------------------------------------
+% Make a new chunk float to attach label and caption to
+\DeclareNewFloatType{chunk}{placement=H, fileext=chk, within=chapter, name=Chunk}
+\crefname{chunk}{Chunk}{chunks}
+\Crefname{chunk}{Chunk}{Chunks}
 %------------------------------------------------------------------------------


### PR DESCRIPTION
Add functionality to allow code chunks to be captioned and cross-referenced.

I would like this functionality for the Stan course, but it may be useful for other courses too.

Examples:

---------
1. **Standard Chunk**

_Input_
~~~
```{r}
(x = 5)
``` 
~~~

_Output_; left unchanged by alteration.

![image](https://user-images.githubusercontent.com/32269169/95843743-f20d7100-0d3f-11eb-82cf-12c8af7f1f5c.png)
---------

2. **Labelled chunk**

_Input_
~~~
```{r codecap = "This is an example of a code caption.", ref = "chk:example"}
## Assign the value 5 to x
x = 5
x
```
In \cref{chk:example} we do computering.
~~~
_Output_; caption is placed below chunk.
![image](https://user-images.githubusercontent.com/32269169/95844603-fe45fe00-0d40-11eb-80bd-92a154cc96fd.png)

---------