### PR TITLE
Caption and cross-reference code chunks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: jrNotes
 Title: Jumping Rivers: Helper Package for Notes
-Version: 0.9.3
+Version: 0.9.4
 Authors@R:
     person(given = "Jumping",
            family = "Rivers",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# jrNotes 0.9.4 _2020-10-13_
+  * Improvement: Allow captioning and cross-referencing of code chunks
+
 # jrNotes 0.9.3 _2020-10-12_
   * Improvement: Improved styling of chapter section and subsections
 

--- a/R/set_knitr_options.R
+++ b/R/set_knitr_options.R
@@ -93,6 +93,22 @@ set_knitr_options = function(tidy = FALSE,
     }
     hook_output(x, options)
   })
+
+  hook_old = knit_hooks$get("chunk")
+  knit_hooks$set(chunk = function(x, options) {
+    if (!is.null(options$code.cap)) {
+      # Open marginpar and add caption
+      tex = paste0("\\marginpar{\\captionof{chunk}{", options$code.cap, "}")
+      if (!is.null(options$label)) {
+        # Add label inside marginpar
+        tex = paste0(tex, "\\label{chk:", options$label, "}")
+      }
+      # Prepend tex and close marginpar
+      x = paste0(tex, "}", x)
+    }
+    hook_old(x, options)
+  })
+
   con = config::get()
   if (!is.null(con$knitr)) {
     do.call(knitr::opts_chunk$set, con$knitr)

--- a/inst/extdata/jrStyle.sty
+++ b/inst/extdata/jrStyle.sty
@@ -223,7 +223,6 @@
 % Big 'ol chapter number
 \newfontfamily\chapterNumber[Scale=6]{Linux Libertine O}
 
-
 % Format chapter
 \titleformat{\chapter}%
 [display]% shape
@@ -251,4 +250,12 @@
 {0em}% horizontal separation between label and title body
 {\slshape}% before the title body
 []% after the title body
+%------------------------------------------------------------------------------
+
+%------------------------------------------------------------------------------
+% Make a new chunk float to attach label and caption to
+\DeclareNewFloatType{chunk}{placement=H, fileext=chk, within=chapter, name=Chunk}
+\crefname{chunk}{Chunk}{chunks}
+\Crefname{chunk}{Chunk}{Chunks}
+\captionsetup[chunk]{font=small}
 %------------------------------------------------------------------------------


### PR DESCRIPTION
This change allows captioning and cross-referencing of code chunks.

Captions are specified with the `code.cap` chunk option.

Labels, for cross-referencing, can be specified with the `label` argument. All labels are then prefixed with `chk:`.

----
### Example

The following code creates a code chunk with caption and label:
~~~
```{r code.cap = "This is an example of a code caption.", label = "example"}
## Assign the value 5 to x
x = 5
x
```
In \cref{chk:example} we do computering.
~~~
This code chunk can then be cross-referenced as `\cref{chk:example}` or `Chunk \ref{chk:example}`.
### Output
![image](https://user-images.githubusercontent.com/32269169/95963318-72df7200-0dff-11eb-97f4-dd150aba5d79.png)


