### PR TITLE
Fixes #76

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: jrNotes
 Title: Jumping Rivers: Helper Package for Notes
-Version: 0.9.5
+Version: 0.9.6
 Authors@R:
     person(given = "Jumping",
            family = "Rivers",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# jrNotes 0.9.6 _2020-10-15_
+  * Bug: `floatrow` and `tufte-book` both define figure\*. Swap `floatrow` for
+    `newfloat`.
+
 # jrNotes 0.9.5 _2020-10-13_
   * Bug: `config$r_packages` should be added to spelling exemptions
 

--- a/inst/extdata/jrStyle.sty
+++ b/inst/extdata/jrStyle.sty
@@ -10,10 +10,11 @@
 \usepackage[capitalise,noabbrev,nameinlink]{cleveref}
 \usepackage{colortbl}
 \usepackage{etoolbox}
-\usepackage{floatrow}
+\usepackage{float}
 \usepackage{fontspec}
 \usepackage{framed}
 \usepackage{microtype}
+\usepackage{newfloat}
 \usepackage[parfill]{parskip}
 % Formatting of subfigures
 \usepackage{subfig}
@@ -254,8 +255,11 @@
 
 %------------------------------------------------------------------------------
 % Make a new chunk float to attach label and caption to
-\DeclareNewFloatType{chunk}{placement=H, fileext=chk, within=chapter, name=Chunk}
-\crefname{chunk}{Chunk}{chunks}
+\DeclareFloatingEnvironment[fileext=chk,
+                            name=Chunk,
+                            placement=H,
+                            within=chapter]{chunk}
+\crefname{chunk}{Chunk}{Chunks}
 \Crefname{chunk}{Chunk}{Chunks}
 \captionsetup[chunk]{font=small}
 %------------------------------------------------------------------------------


### PR DESCRIPTION
`floatrow` and `tufte-book` both define a `figure*` enviornment, and so don't play well together.

Instead of using `floatrow`, here I use the similar `newfloat` package.

--------
Current `fig.fullwidth` (taken from ggplot2)

![09:40:57](https://user-images.githubusercontent.com/32269169/96101152-134f9800-0ecd-11eb-848a-d981f0a7e52e.png)

--------
Fixed `full.width` (again ggplot2)
![09:43:18](https://user-images.githubusercontent.com/32269169/96101195-1e0a2d00-0ecd-11eb-947e-40ff613b2b8d.png)


--------
This keeps code captions and cross-referencing.