### PR TITLE
Number subsections

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: jrNotes
 Title: Jumping Rivers: Helper Package for Notes
-Version: 0.9.7
+Version: 0.9.8
 Authors@R:
     person(given = "Jumping",
            family = "Rivers",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# jrNotes 0.9.8 _2020-10-26_
+  * Improvement: Number subsections in pdf builds.
+
 # jrNotes 0.9.7 _2020-10-21_
   * Improvement: display version of jrNotes when building
 

--- a/inst/extdata/jrStyle.sty
+++ b/inst/extdata/jrStyle.sty
@@ -135,7 +135,7 @@
 \patchcmd{\ttlh@hang}{\parindent\z@}{\parindent\z@\leavevmode}{}{}
 \patchcmd{\ttlh@hang}{\noindent}{}{}{}
 \makeatother
-\setcounter{secnumdepth}{1}
+\setcounter{secnumdepth}{2}
 %------------------------------------------------------------------------------
 
 %------------------------------------------------------------------------------


### PR DESCRIPTION
We often use subsections, but we don't number them. (the default of tufte-book2 _does_ number subsections)

Should we number subsections? I quite like it for longer notes...

This PR would number subsections.