### PR TITLE
WIP: fail ci; fix indent

### DIFF
--- a/inst/extdata/jrStyle.sty
+++ b/inst/extdata/jrStyle.sty
@@ -55,18 +55,12 @@
 
 % Paragraph indentation and separation for normal text
 \renewcommand{\@tufte@reset@par}{%
-  \setlength{\RaggedRightParindent}{0.0pc}%
-  \setlength{\JustifyingParindent}{0.0pc}%
-  \setlength{\parindent}{0pc}%
   \setlength{\parskip}{2.5pt}%
 }
 \@tufte@reset@par
 
 % Paragraph indentation and separation for marginal text
 \renewcommand{\@tufte@margin@par}{%
-  \setlength{\RaggedRightParindent}{0.0pc}%
-  \setlength{\JustifyingParindent}{0.0pc}%
-  \setlength{\parindent}{0.0pc}%
   \setlength{\parskip}{10pt}%
 }
 \makeatother


### PR DESCRIPTION
Addressing #90 

@csgillespie What is going on with our usage of `\indent`? As it stands `jrStyle.sty` has been set to remove **all** horizontal paragraph indentation. But then we seem to add it back in as desired with `\indent`s all the time.

This PR removes the code in `jrStyle` which sets the horizontal paragraph indentation to 0. Do we prefer this (the use of `\indent` in all the courses seems to suggest that we do)?.

If this PR was accepted then until `\indent` was removed from the notes then all paragraphs would be doubly indented.