### PR TITLE
Ignore Latex commands in the spell checker

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: jrNotes
 Title: Jumping Rivers: Helper Package for Notes
-Version: 0.10.4
+Version: 0.10.5
 Authors@R:
     person(given = "Jumping",
            family = "Rivers",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# jrNotes 0.10.5 _2020-11-14_
+  * Spelling: Ignore LaTeX commands when spell checking
+
 # jrNotes 0.10.4 _2020-11-10_
   * Bug: Remove extra whitespaces in clean_title
 

--- a/R/check_spelling.R
+++ b/R/check_spelling.R
@@ -80,6 +80,11 @@ check_spelling = function() {
   words = get_words()
   fnames = list.files(pattern = "^c.*\\.Rmd$")
   in_words = spelling::spell_check_files(fnames, lang = "en_GB", ignore = words)
+  ## Spell check main.tex with LaTeX filter
+  main_words = spelling::spell_check_files("main.tex", lang = "en_GB", ignore = words)
+  ## Words that don't appear in main are OK
+  in_words = in_words[in_words$word %in% main_words$word, ]
+
   if (nrow(in_words) == 0L) {
     msg_success("Spell check passed")
     return(invisible(NULL))

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -3,45 +3,6 @@ etc
 IMDB
 YAML
 
-## Latex
-bigskip
-bottomrule
-cdots
-center
-centering
-clearpage
-cmidrule
-columnwidth
-emph
-hspace
-includegraphics
-ldots
-marginfigure
-marginnote
-margintable
-mbox
-medskip
-midrule
-newcommand
-newpage
-newthought
-noindent
-resizebox
-sidenote
-smallskip
-textbackslash
-textbf
-textit
-textrm
-textsc
-textsl
-texttt
-textwidth
-tilda
-toprule
-vdots
-vspace
-
 ## Names
 RStudio
 


### PR DESCRIPTION
We have a horrible mixture of latex and Rmd. 

General idea:

 * Spell check assuming they are md files (what we currently do). This strips out R code and gives file/line numbers
 * Spell check the generated latex file - strips out latex files
 * Take the intersection of the two lists

See also https://github.com/ropensci/spelling/issues/56

---

Fixes #64 
