### PR TITLE
Refactor create_live()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: jrNotes
 Title: Jumping Rivers: Helper Package for Notes
-Version: 0.10.8
+Version: 0.10.9
 Authors@R:
     person(given = "Jumping",
            family = "Rivers",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# jrNotes 0.10.9 _2020-12-09_
+  * Refactor `create_live()` to allow different paths
+
 # jrNotes 0.10.8 _2020-12-07_
   * Bug: Update `get_pkg_imports()` to factor in pkgs with no defined imports
 

--- a/R/create_live.R
+++ b/R/create_live.R
@@ -6,25 +6,25 @@
 #' Zips VM folder ready to be exposed as an artifact
 #' @importFrom fs dir_ls file_copy
 #' @importFrom stringr str_to_lower str_subset str_replace
+#' @param live_path The path to the live directory
 #' @export
-create_live_scripts = function() {
-
+create_live_scripts = function(live_path = "../live") {
   if (get_repo_language() == "python") {
-    create_live_python()
+    create_live_python(live_path = live_path)
   } else {
-    if (!fs::dir_exists("../live")) return(invisible(NULL))
+    if (!fs::dir_exists(live_path)) return(invisible(NULL))
 
     msg_start("Creating scripts for VM...")
 
     # Create new folders and ensure empty
-    chapters = list.files(path = "../live/", pattern = "chapter")
+    chapters = list.files(path = live_path, pattern = "chapter")
 
-    dir.create("../live/vm_scripts", showWarnings = FALSE)
-    unlink(list.files("../live/vm_scripts", full.names = TRUE, include.dirs = TRUE),
+    dir.create(glue("{live_path}/vm_scripts"), showWarnings = FALSE)
+    unlink(list.files(glue("{live_path}/vm_scripts"), full.names = TRUE, include.dirs = TRUE),
            recursive = TRUE)
 
-    dir.create("../live/tutor_scripts", showWarnings = FALSE)
-    unlink(list.files("../live/tutor_scripts", full.names = TRUE, include.dirs = TRUE),
+    dir.create(glue("{live_path}/tutor_scripts"), showWarnings = FALSE)
+    unlink(list.files(glue("{live_path}/tutor_scripts"), full.names = TRUE, include.dirs = TRUE),
            recursive = TRUE)
 
     # Set up file extension
@@ -37,49 +37,49 @@ create_live_scripts = function() {
 
     for (chapter in chapters) {
       # Create folder
-      dir.create(glue("../live/vm_scripts/{chapter}", showWarnings = FALSE))
+      dir.create(glue("{live_path}/vm_scripts/{chapter}", showWarnings = FALSE))
 
       # Check for images
-      files = list.files(glue("../live/{chapter}"), full.names = TRUE)
+      files = list.files(glue("{live_path}/{chapter}"), full.names = TRUE)
       imgs = str_subset(files, "\\.png$")
 
       # Copy images
       if (length(imgs) > 0) {
         fs::file_copy(
           path = imgs,
-          new_path = str_replace(imgs, "live", "live/vm_scripts"),
+          new_path = str_replace(imgs, live_path, glue("{live_path}/vm_scripts")),
           overwrite = TRUE
         )
       }
 
       # Create tutor scripts
-      if (file.exists(glue("../live/{chapter}/master_tutor.{ext}"))) {
+      if (file.exists(glue("{live_path}/{chapter}/master_tutor.{ext}"))) {
 
         # Create tutor_scripts/chapterX.{ext}
         system2("sed",
-                args = c(shQuote("/^#>.*/d"), glue("../live/{chapter}/master_tutor.{ext}")),
-                stdout = glue("../live/tutor_scripts/{chapter}.{ext}"))
+                args = c(shQuote("/^#>.*/d"), glue("{live_path}/{chapter}/master_tutor.{ext}")),
+                stdout = glue("{live_path}/tutor_scripts/{chapter}.{ext}"))
 
         # Create vm_scripts/chapterX/tutor.{ext}
         system2("sed",
-                args = c(shQuote("s/^#> //"), glue("../live/{chapter}/master_tutor.{ext}")),
-                stdout = glue("../live/vm_scripts/{chapter}/tutor.{ext}"))
+                args = c(shQuote("s/^#> //"), glue("{live_path}/{chapter}/master_tutor.{ext}")),
+                stdout = glue("{live_path}/vm_scripts/{chapter}/tutor.{ext}"))
       }
 
       # Create exercises and solutions
-      if (file.exists(glue("../live/{chapter}/master_exercises.{ext}"))) {
+      if (file.exists(glue("{live_path}/{chapter}/master_exercises.{ext}"))) {
 
         # Create exercises_original.{ext}
         ## Delete lines starting with #>
         ## Keep lines starting with #<
         system2("sed",
                 args = c(shQuote("/^#>.*/d ; s/^#< //"),
-                         glue("../live/{chapter}/master_exercises.{ext}")),
-                stdout = glue("../live/vm_scripts/{chapter}/exercises_original.{ext}"))
+                         glue("{live_path}/{chapter}/master_exercises.{ext}")),
+                stdout = glue("{live_path}/vm_scripts/{chapter}/exercises_original.{ext}"))
 
         # Create exercises.{ext}
-        fs::file_copy(path = glue("../live/vm_scripts/{chapter}/exercises_original.{ext}"),
-                      new_path = glue("../live/vm_scripts/{chapter}/exercises.{ext}"),
+        fs::file_copy(path = glue("{live_path}/vm_scripts/{chapter}/exercises_original.{ext}"),
+                      new_path = glue("{live_path}/vm_scripts/{chapter}/exercises.{ext}"),
                       overwrite = TRUE)
 
         # Create solutions.{ext}
@@ -87,22 +87,24 @@ create_live_scripts = function() {
         ## Keep lines starting with #>
         system2("sed",
                 args = c(shQuote("/^#<.*/d ; s/^#> //"),
-                         glue("../live/{chapter}/master_exercises.{ext}")),
-                stdout = glue("../live/vm_scripts/{chapter}/solutions.{ext}"))
+                         glue("{live_path}/{chapter}/master_exercises.{ext}")),
+                stdout = glue("{live_path}/vm_scripts/{chapter}/solutions.{ext}"))
       }
     }
 
     # Zip folder
     msg_info("Zipping scripts...", padding = TRUE)
     # Copy notes into vm_scripts.zip
-    fs::file_copy("main.pdf", "../live/vm_scripts/notes.pdf", overwrite = TRUE)
+    fs::file_copy("main.pdf", glue("{live_path}/vm_scripts/notes.pdf"), overwrite = TRUE)
 
-    zip::zipr(zipfile = "../live/tutor_scripts.zip", files = "../live/tutor_scripts/")
-    zip::zipr(zipfile = "../live/vm_scripts.zip", files = "../live/vm_scripts/")
+    zip::zipr(zipfile = glue("{live_path}/tutor_scripts.zip"),
+              files = glue("{live_path}/tutor_scripts/"))
+    zip::zipr(zipfile = glue("{live_path}/vm_scripts.zip"),
+              files = glue("{live_path}/vm_scripts/"))
 
     # Clean up
-    unlink("../live/vm_scripts/", recursive = TRUE)
-    unlink("../live/tutor_scripts/", recursive = TRUE)
+    unlink(glue("{live_path}/vm_scripts/"), recursive = TRUE)
+    unlink(glue("{live_path}/tutor_scripts/"), recursive = TRUE)
 
     msg_success("Live scripts created and zipped")
   }
@@ -119,81 +121,85 @@ create_live_scripts = function() {
 #'
 #' @importFrom fs dir_ls file_copy
 #' @importFrom glue glue
-create_live_python = function() {
+#' @param live_path The location to the live directory
+create_live_python = function(live_path) {
 
-  if (!fs::dir_exists("../live")) return(invisible(NULL))
+  if (!fs::dir_exists(live_path)) return(invisible(NULL))
 
   msg_start("Creating scripts for VM...")
 
-  chapters = list.files(path = "../live/", pattern = "chapter")
+  chapters = list.files(path = live_path, pattern = "chapter")
 
-  dir.create("../live/vm_scripts", showWarnings = FALSE)
-  unlink(list.files("../live/vm_scripts", full.names = TRUE, include.dirs = TRUE),
+  dir.create(glue("{live_path}/vm_scripts"), showWarnings = FALSE)
+  unlink(list.files(glue("{live_path}/vm_scripts"), full.names = TRUE, include.dirs = TRUE),
          recursive = TRUE)
 
-  dir.create("../live/tutor_scripts", showWarnings = FALSE)
-  unlink(list.files("../live/tutor_scripts", full.names = TRUE, include.dirs = TRUE),
+  dir.create(glue("{live_path}/tutor_scripts"), showWarnings = FALSE)
+  unlink(list.files(glue("{live_path}/tutor_scripts"), full.names = TRUE, include.dirs = TRUE),
          recursive = TRUE)
 
   for (chapter in chapters) {
     # Create folder
-    dir.create(glue::glue("../live/vm_scripts/{chapter}", showWarnings = FALSE))
+    dir.create(glue::glue("{live_path}/vm_scripts/{chapter}", showWarnings = FALSE))
 
     # Create tutor scripts
-    if (file.exists(glue::glue("../live/{chapter}/master_tutor.Rmd"))) {
+    if (file.exists(glue::glue("{live_path}/{chapter}/master_tutor.Rmd"))) {
 
       # Create tutor_scripts/chapterX.py
       system2("sed",
-              args = c(shQuote("/^#>.*/d"), glue::glue("../live/{chapter}/master_tutor.Rmd")),
-              stdout = glue::glue("../live/tutor_scripts/{chapter}.Rmd"))
+              args = c(shQuote("/^#>.*/d"), glue::glue("{live_path}/{chapter}/master_tutor.Rmd")),
+              stdout = glue::glue("{live_path}/tutor_scripts/{chapter}.Rmd"))
       # convert tutor scripts to notebooks
-      system2("jupytext", c("--to", "notebook", glue::glue("../live/tutor_scripts/{chapter}.Rmd")))
+      system2("jupytext", c("--to", "notebook",
+                            glue::glue("{live_path}/tutor_scripts/{chapter}.Rmd")))
 
       # Create vm_scripts/chapterX/tutor.R
       system2("sed",
-              args = c(shQuote("s/^#> //"), glue::glue("../live/{chapter}/master_tutor.Rmd")),
-              stdout = glue::glue("../live/vm_scripts/{chapter}/tutor.Rmd"))
+              args = c(shQuote("s/^#> //"), glue::glue("{live_path}/{chapter}/master_tutor.Rmd")),
+              stdout = glue::glue("{live_path}/vm_scripts/{chapter}/tutor.Rmd"))
 
       # convert student scripts to notebooks
       system2(
         "jupytext",
         c(
           "--to", "notebook",
-          glue::glue("../live/vm_scripts/{chapter}/tutor.Rmd")
+          glue::glue("{live_path}/vm_scripts/{chapter}/tutor.Rmd")
         )
       )
     }
 
     # Create exercises and solutions
-    if (file.exists(glue::glue("../live/{chapter}/master_exercises.Rmd"))) {
+    if (file.exists(glue::glue("{live_path}/{chapter}/master_exercises.Rmd"))) {
 
       # Create exercises_original.R
       system2("sed",
-              args = c(shQuote("/^#>.*/d"), glue::glue("../live/{chapter}/master_exercises.Rmd")),
-              stdout = glue::glue("../live/vm_scripts/{chapter}/exercises_original.Rmd"))
+              args = c(shQuote("/^#>.*/d"),
+                       glue::glue("{live_path}/{chapter}/master_exercises.Rmd")),
+              stdout = glue::glue("{live_path}/vm_scripts/{chapter}/exercises_original.Rmd"))
       system2(
         "jupytext",
         c(
           "--to", "notebook",
-          glue::glue("../live/vm_scripts/{chapter}/exercises_original.Rmd")
+          glue::glue("{live_path}/vm_scripts/{chapter}/exercises_original.Rmd")
         )
       )
 
       # Create excercises.R
-      fs::file_copy(path = glue::glue("../live/vm_scripts/{chapter}/exercises_original.ipynb"),
-                    new_path = glue::glue("../live/vm_scripts/{chapter}/exercises.ipynb"),
+      fs::file_copy(path = glue::glue("{live_path}/vm_scripts/{chapter}/exercises_original.ipynb"),
+                    new_path = glue::glue("{live_path}/vm_scripts/{chapter}/exercises.ipynb"),
                     overwrite = TRUE)
 
       # Create solutions.R
       system2("sed",
-              args = c(shQuote("s/^#> //"), glue::glue("../live/{chapter}/master_exercises.Rmd")),
-              stdout = glue::glue("../live/vm_scripts/{chapter}/solutions.Rmd"))
+              args = c(shQuote("s/^#> //"),
+                       glue::glue("{live_path}/{chapter}/master_exercises.Rmd")),
+              stdout = glue::glue("{live_path}/vm_scripts/{chapter}/solutions.Rmd"))
 
       system2(
         "jupytext",
         c(
           "--to", "notebook",
-          glue::glue("../live/vm_scripts/{chapter}/solutions.Rmd")
+          glue::glue("{live_path}/vm_scripts/{chapter}/solutions.Rmd")
         )
       )
 
@@ -203,18 +209,22 @@ create_live_python = function() {
   # Zip folder
   msg_start("Zipping scripts...")
   # clear out the Rmd files first
-  unlink(list.files("../live/tutor_scripts", "Rmd$", full.names = TRUE, recursive =  TRUE))
-  unlink(list.files("../live/vm_scripts", "Rmd$", full.names = TRUE, recursive =  TRUE))
+  unlink(list.files(glue("{live_path}/tutor_scripts"),
+                    "Rmd$", full.names = TRUE, recursive =  TRUE))
+  unlink(list.files(glue("{live_path}/vm_scripts"),
+                    "Rmd$", full.names = TRUE, recursive =  TRUE))
 
   # Copy notes into vm_scripts.zip
-  fs::file_copy("main.pdf", "../live/vm_scripts/notes.pdf", overwrite = TRUE)
+  fs::file_copy("main.pdf", glue("{live_path}/vm_scripts/notes.pdf"), overwrite = TRUE)
 
-  zip::zipr(zipfile = "../live/tutor_scripts.zip", files = "../live/tutor_scripts")
-  zip::zipr(zipfile = "../live/vm_scripts.zip", files = "../live/vm_scripts")
+  zip::zipr(zipfile = glue("{live_path}/tutor_scripts.zip"),
+            files = glue("{live_path}/tutor_scripts"))
+  zip::zipr(zipfile = glue("{live_path}/vm_scripts.zip"),
+            files = glue("{live_path}/vm_scripts"))
 
   # Clean up
-  unlink("../live/vm_scripts/", recursive = TRUE)
-  unlink("../live/tutor_scripts/", recursive = TRUE)
+  unlink(glue("{live_path}/vm_scripts/"), recursive = TRUE)
+  unlink(glue("{live_path}/tutor_scripts/"), recursive = TRUE)
 
   msg_success("Live scripts created and zipped")
 }

--- a/R/create_live.R
+++ b/R/create_live.R
@@ -9,12 +9,14 @@
 #' @param live_path The path to the live directory
 #' @export
 create_live_scripts = function(live_path = "../live") {
+
+  if (!fs::dir_exists(live_path)) return(invisible(NULL))
+
+  msg_start("Creating scripts for VM...")
+
   if (get_repo_language() == "python") {
     create_live_python(live_path = live_path)
   } else {
-    if (!fs::dir_exists(live_path)) return(invisible(NULL))
-
-    msg_start("Creating scripts for VM...")
 
     # Create new folders and ensure empty
     chapters = list.files(path = live_path, pattern = "chapter")
@@ -123,10 +125,6 @@ create_live_scripts = function(live_path = "../live") {
 #' @importFrom glue glue
 #' @param live_path The location to the live directory
 create_live_python = function(live_path) {
-
-  if (!fs::dir_exists(live_path)) return(invisible(NULL))
-
-  msg_start("Creating scripts for VM...")
 
   chapters = list.files(path = live_path, pattern = "chapter")
 

--- a/man/create_live_python.Rd
+++ b/man/create_live_python.Rd
@@ -4,7 +4,10 @@
 \alias{create_live_python}
 \title{Create live python}
 \usage{
-create_live_python()
+create_live_python(live_path)
+}
+\arguments{
+\item{live_path}{The location to the live directory}
 }
 \description{
 Creates a vm_scripts folder

--- a/man/create_live_scripts.Rd
+++ b/man/create_live_scripts.Rd
@@ -4,7 +4,10 @@
 \alias{create_live_scripts}
 \title{Create scripts for online training}
 \usage{
-create_live_scripts()
+create_live_scripts(live_path = "../live")
+}
+\arguments{
+\item{live_path}{The path to the live directory}
 }
 \description{
 Creates a vm_scripts folder


### PR DESCRIPTION
Allow `create_live()` to work on paths other than `../live`

I need this functionality to create live scripts from the sub-directory `bio` for the Crick courses in January.
For the Crick courses in January - I'll run jrNotes locally to create the bio zips, and manually update the VM. 
Once the "new" notes system is settled we should be able to handle this edge case in a more sensible way.

Also - check_all() failed when I ran locally, but passed the build. I think the tagging was picking up an error that wasn't there?