### PR TITLE
Provision venv dir

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: jrNotes
 Title: Jumping Rivers: Helper Package for Notes
-Version: 0.10.10
+Version: 0.11.1
 Authors@R:
     person(given = "Jumping",
            family = "Rivers",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# jrNotes 0.11.1 _2020-12-14_
+  * Internal: Allow `provision_venv()` to create virtualenv in places other
+    than just the `notes/` directory
+
 # jrNotes 0.10.10 _2020-12-11_
   * Improvement: Improve tango syntax highlighting support for Python
 

--- a/R/create_venv.R
+++ b/R/create_venv.R
@@ -2,19 +2,21 @@
 #' installed
 #'
 #' @description Create and use a virtualenv with python packages listed in config.yml
+#' @param venv_dir The directory in which to create the virtualenv (typically
+#' "notes" or "slides")
 #' installed
 #' @export
-provision_venv = function() {
+provision_venv = function(venv_dir = "notes") {
   ## Get python packages listed in config.yml
   pkgs = get_python_pkg_name()
 
   ## If no python packages listed don't do anything
   if (length(pkgs) == 0L) return(invisible(NULL))
   msg_start("Creating a venv...provision_venv()")
-  venv_path = file.path(get_root_dir(), "notes", "venv")
+  venv_path = file.path(get_root_dir(), venv_dir, "venv")
   ## If a virtualenv hasn't already been made, make it
   if (!dir.exists(venv_path)) {
-    create_venv(pkgs)
+    create_venv(pkgs, venv_dir)
   }
 
   ## Activate the virtualenv
@@ -22,14 +24,14 @@ provision_venv = function() {
   Sys.setenv("RETICULATE_PYTHON" = file.path(venv_path, "/bin/python"))
 }
 
-create_venv = function(pkgs) {
+create_venv = function(pkgs, venv_dir) {
   ## Unique in case jrpytests or jupytext listed in config.yml
   pkgs = unique(c(pkgs, "jrpytests", "jupytext"))
 
   ## By default reticulate creates virtualenvs in ~/.virtualenv
   ## To change where the virtualenv is created we have to use
   ## the WORKON_HOME environment variable
-  Sys.setenv(WORKON_HOME = file.path(get_root_dir(), "notes"))
+  Sys.setenv(WORKON_HOME = file.path(get_root_dir(), venv_dir))
 
   ## Create the virtualenv
   reticulate::virtualenv_create(envname = "venv",

--- a/man/provision_venv.Rd
+++ b/man/provision_venv.Rd
@@ -5,9 +5,13 @@
 \title{Create and use a virtualenv with python packages listed in config.yml
 installed}
 \usage{
-provision_venv()
+provision_venv(venv_dir = "notes")
+}
+\arguments{
+\item{venv_dir}{The directory in which to create the virtualenv (typically
+"notes" or "slides")
+installed}
 }
 \description{
 Create and use a virtualenv with python packages listed in config.yml
-installed
 }


### PR DESCRIPTION
`provision_venv()` creates a virtualenv in the `notes/` directory of the project root.

However, we may wish to create a virtualenv in other directories. (ie. the `slides/` directory).

We currently provision the virtualenv when building slides with the old `cat requirements.txt` workflow.

This change would allow us to update the slides build workflow to be similar to the notes build workflow